### PR TITLE
Add lansingerland municipality.

### DIFF
--- a/_labs/lansingerland.yml
+++ b/_labs/lansingerland.yml
@@ -1,0 +1,39 @@
+---
+key: lansingerland
+title: Burgermeetnet Lansingerland
+lat: 51.994556
+long: 4.489500
+
+# translations for titles
+meetings_title: Meetings
+contacts_title: Contact
+
+# If you need to include a link in this texts, don't forget to add  "target='_blank' rel='noreferrer'". Otherwise link will be removed.
+meetings:
+- text: Het Burgermeetnet Lansingerland (BML) meet de concentratie fijnstof in de lucht en brengt de luchtkwaliteit in kaart
+
+# multiple contacts possible
+# - name: name of contact
+#   url: email address or url of contact form
+contacts:
+- name: Martin Liefting
+  url: mailto:martin.liefting@gmail.com
+- name: Eddy Cornelisse
+  url: mailto:eddy.cornelisse@gmail.com
+
+# leave empty if non-existent
+# Twitter and Telegram: account name without @ sign
+website: http://burgermeetnetlansingerland.nl/
+facebook:
+facebook_group:
+facebook_page: BurgerMeetnetLansingerland
+github:
+gitlab:
+instagram:
+mastodon:
+meetup:
+telegram:
+telegram_group:
+twitter:
+linkedin: https://www.linkedin.com/groups/12475407/
+


### PR DESCRIPTION
I'd like to add this local lab for the municipality ("gemeente") lansingerland, on behalf of Martin Liefting who is the coordinator for the initiative in that municipality.