### PR TITLE
Update brussels.yml

### DIFF
--- a/_labs/brussels.yml
+++ b/_labs/brussels.yml
@@ -1,14 +1,14 @@
 ---
 key: civic_lab_brussels
 title: Civic Lab Brussels
-lat: 50.845369
-long: 4.357297
+lat: 50.85563
+long: 4.32116
 
 meetings:
-- text: bi-weekly
+- text: first tuesday of the month
 
 contacts:
-- name: Dries van R.
-  url: http://influencair.be/
-
-website: http://influencair.be/
+- name: Rik Drabs
+  url: https://www.meetup.com/nl-NL/civic-lab-brussels/
+  website: https://www.meetup.com/nl-NL/civic-lab-brussels/
+  mail: influencair2017@gmail.com 


### PR DESCRIPTION
Restart operations by a new organiser since mid-2023 (myself) Meeting place moved to premises of Hacker Space Brussels, with which a cooperation was started.  All old data on Civic Lab Brussels was not correct anymore. New organiser, new meeting place, new meeting schedule, etc.